### PR TITLE
Update path to Muban's seng-generator templates

### DIFF
--- a/tool/convert.js
+++ b/tool/convert.js
@@ -6,7 +6,7 @@ const actions = [
   {
     type: actionType.RUN,
     label: 'Update the seng-generator template path.',
-    command: 'sg settings -t ./template,./node_modules/muban-transition-component/template',
+    command: 'sg settings -t ./build-tools/template,./node_modules/muban-transition-component/template',
   },
   {
     type: actionType.REPLACE,


### PR DESCRIPTION
The seng-generator templates are now stored in the build-tools folder. This pull request will update the path which is used when using the automated override